### PR TITLE
update nyc report command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,7 @@ istanbul cover ./node_modules/lab/bin/lab --report lcovonly  -- -l  && codecov
 ```javascript
 {
   "scripts": {
-    "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
+    "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     ...
   }
   ...


### PR DESCRIPTION
The "--reporter=lcov" does not generate a full report, but --reporter=text-lcov" does.