### PR TITLE
fix: changed nyc example 🦄 

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ istanbul cover ./node_modules/lab/bin/lab --report lcovonly  -- -l  && codecov
 ```javascript
 {
   "scripts": {
-    "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
+    "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     ...
   }
   ...


### PR DESCRIPTION
Of the following [reports available for NYC](https://github.com/istanbuljs/istanbuljs/tree/master/packages/istanbul-reports/lib), I believe most people prefer `text-lcov`, as it generates a robust text only report report.

`text-lcov` could be used for the purposes of piping the output directly to a service like codecov, vs., `lcov` which places a file on disk which you can work with.

the other examples of `coveralls.io` include this in their [examples](https://www.npmjs.com/package/coveralls#nyc), I think codecov should also use it for their example. 