### PR TITLE
doc: update Istanbul example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ YOURPACKAGE_COVERAGE=1 ./node_modules/.bin/mocha test -R mocha-lcov-reporter
 **With Mocha:**
 
 ```sh
-nyc mocha --report lcovonly -- -R spec && codecov
+nyc --reporter=lcov mocha && codecov
 ```
 
 **With Jasmine:**


### PR DESCRIPTION
The Istanbul+Mocha example can't work in the latest Istanbul, so I updated it according to this document
https://github.com/istanbuljs/nyc/blob/master/docs/setup-codecov.md#without-npx---travis-ci-example-using-npm-scripts